### PR TITLE
Readability refactoring to the main pkg

### DIFF
--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -10,7 +10,6 @@ import (
 	"runtime"
 	"strings"
 	"syscall"
-	"text/tabwriter"
 
 	"github.com/probr/probr-sdk/plugin"
 	"github.com/probr/probr-sdk/probeengine"
@@ -109,31 +108,4 @@ func GetPackNames() (packNames []string, err error) {
 		return hcplugin.Discover("*", config.Vars.BinariesPath)
 	}
 	return config.Vars.Run, nil
-}
-
-// ListServicePacks lists all service packs declared in config and checks if they are installed
-func ListServicePacks() {
-	servicePackNames, err := GetPackNames()
-	if err != nil {
-		log.Fatalf("An error occurred while retriveing service packs from config: %v", err)
-	}
-
-	servicePacks := make(map[string]string)
-	for _, pack := range servicePackNames {
-		binaryPath, binErr := GetPackBinary(pack)
-		binaryName := filepath.Base(binaryPath)
-		if binErr != nil {
-			servicePacks[binaryName] = fmt.Sprintf("ERROR: %v", binErr)
-		} else {
-			servicePacks[binaryName] = "OK"
-		}
-	}
-
-	// Print output
-	writer := tabwriter.NewWriter(os.Stdout, 1, 1, 1, ' ', 0)
-	fmt.Fprintln(writer, "| Service Pack\t | Installed ")
-	for k, v := range servicePacks {
-		fmt.Fprintf(writer, "| %s\t | %s\n", k, v)
-	}
-	writer.Flush()
 }

--- a/main.go
+++ b/main.go
@@ -4,12 +4,11 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
-
-	"github.com/probr/probr-sdk/plugin"
+	"text/tabwriter"
 
 	"github.com/probr/probr/internal/core"
 	"github.com/probr/probr/internal/flags"
+	"github.com/probr/probr/run"
 )
 
 var (
@@ -40,7 +39,7 @@ func main() {
 	// Ref: https://gobyexample.com/command-line-subcommands
 	case "list":
 		flags.List.Parse(os.Args[2:])
-		core.ListServicePacks()
+		listServicePacks()
 
 	case "version":
 		flags.Version.Parse(os.Args[2:])
@@ -48,89 +47,16 @@ func main() {
 
 	default:
 		flags.Run.Parse(os.Args[1:])
-		run()
+		run.CLIContext()
 	}
-}
-
-func run() {
-	// Setup for handling SIGTERM (Ctrl+C)
-	core.SetupCloseHandler()
-
-	cmdSet, err := core.GetCommands()
-	if err != nil {
-		log.Printf("Error loading plugins from config: %s", err)
-		os.Exit(2)
-	}
-
-	// Run all plugins
-	if err := runAllPlugins(cmdSet); err != nil {
-		switch e := err.(type) {
-		case *core.ServicePackErrors:
-			log.Printf("Test Failures: %d out of %d test service packs failed", len(e.SPErrs), len(cmdSet))
-			log.Printf("Failed service packs: %v", e.SPErrs)
-			os.Exit(1) // At least one service pack failed
-		default:
-			log.Printf("Internal plugin error: %v", err)
-			os.Exit(2) // Internal error
-		}
-	}
-	log.Printf("Success")
-	os.Exit(0)
-}
-
-func runAllPlugins(cmdSet []*exec.Cmd) (err error) {
-	spErrors := make([]core.ServicePackError, 0) // This will store any plugin errors received during execution
-
-	for _, cmd := range cmdSet {
-		spErrors, err = runPlugin(cmd, spErrors)
-		if err != nil {
-			return
-		}
-	}
-
-	if len(spErrors) > 0 {
-		// Return all service pack errors to main
-		err = &core.ServicePackErrors{
-			SPErrs: spErrors,
-		}
-	}
-	return
-}
-
-func runPlugin(cmd *exec.Cmd, spErrors []core.ServicePackError) ([]core.ServicePackError, error) {
-	// Launch the plugin process
-	client := core.NewClient(cmd)
-	defer client.Kill()
-
-	// Connect via RPC
-	rpcClient, err := client.Client()
-	if err != nil {
-		return spErrors, err
-	}
-
-	// Request the plugin
-	rawSP, err := rpcClient.Dispense(plugin.ServicePackPluginName)
-	if err != nil {
-		return spErrors, err
-	}
-
-	// Execute service pack, expecting a silent response
-	servicePack := rawSP.(plugin.ServicePack)
-	response := servicePack.RunProbes()
-	if response != nil {
-		spErr := core.ServicePackError{
-			ServicePack: cmd.String(), // TODO: retrieve service pack name from interface function
-			Err:         response,
-		}
-		spErrors = append(spErrors, spErr)
-	} else {
-		log.Printf("[INFO] Probes all completed with successful results")
-	}
-	return spErrors, nil
 }
 
 func printVersion() {
-	fmt.Fprintf(os.Stdout, "Probr Version: %s", getVersion())
+	if VersionPostfix != "" {
+		Version = fmt.Sprintf("%s-%s", Version, VersionPostfix)
+	}
+
+	fmt.Fprintf(os.Stdout, "Probr Version: %s", Version)
 	if core.Verbose != nil && *core.Verbose {
 		fmt.Fprintln(os.Stdout)
 		fmt.Fprintf(os.Stdout, "Commit       : %s", GitCommitHash)
@@ -139,9 +65,28 @@ func printVersion() {
 	}
 }
 
-func getVersion() string {
-	if VersionPostfix != "" {
-		return fmt.Sprintf("%s-%s", Version, VersionPostfix)
+// listServicePacks reads all service packs declared in config and checks whether they are installed
+func listServicePacks() {
+	servicePackNames, err := core.GetPackNames()
+	if err != nil {
+		log.Fatalf("An error occurred while retrieving service packs from config: %v", err)
 	}
-	return Version
+
+	servicePacks := make(map[string]string)
+	for _, pack := range servicePackNames {
+		_, binErr := core.GetPackBinary(pack)
+		if binErr != nil {
+			servicePacks[pack] = fmt.Sprintf("ERROR: %v", binErr)
+		} else {
+			servicePacks[pack] = "OK"
+		}
+	}
+
+	// Print output
+	writer := tabwriter.NewWriter(os.Stdout, 1, 1, 1, ' ', 0)
+	fmt.Fprintln(writer, "| Service Pack\t | Installed ")
+	for k, v := range servicePacks {
+		fmt.Fprintf(writer, "| %s\t | %s\n", k, v)
+	}
+	writer.Flush()
 }

--- a/main_test.go
+++ b/main_test.go
@@ -35,8 +35,9 @@ func Test_getVersion(t *testing.T) {
 		t.Run(tt.testName, func(t *testing.T) {
 			Version = tt.version
 			VersionPostfix = tt.prerelase
-			if got := getVersion(); got != tt.expectedResult {
-				t.Errorf("getVersion() = %v, expected %v", got, tt.expectedResult)
+			printVersion()
+			if Version != tt.expectedResult {
+				t.Errorf("getVersion() = %v, expected %v", Version, tt.expectedResult)
 			}
 		})
 	}

--- a/run/run.go
+++ b/run/run.go
@@ -1,0 +1,91 @@
+package run
+
+import (
+	"log"
+	"os"
+	"os/exec"
+
+	"github.com/probr/probr-sdk/plugin"
+
+	"github.com/probr/probr/internal/core"
+)
+
+// CLIContext executes all plugins with handling for the command line
+func CLIContext() {
+	// Setup for handling SIGTERM (Ctrl+C)
+	core.SetupCloseHandler()
+
+	cmdSet, err := core.GetCommands()
+	if err != nil {
+		log.Printf("Error loading plugins from config: %s", err)
+		os.Exit(2)
+	}
+
+	// Run all plugins
+	if err := AllPlugins(cmdSet); err != nil {
+		switch e := err.(type) {
+		case *core.ServicePackErrors:
+			log.Printf("Test Failures: %d out of %d test service packs failed", len(e.SPErrs), len(cmdSet))
+			log.Printf("Failed service packs: %v", e.SPErrs)
+			os.Exit(1) // At least one service pack failed
+		default:
+			log.Printf("Internal plugin error: %v", err)
+			os.Exit(2) // Internal error
+		}
+	}
+	log.Printf("Success")
+	os.Exit(0)
+}
+
+// AllPlugins executes specified plugins in a loop
+func AllPlugins(cmdSet []*exec.Cmd) (err error) {
+	spErrors := make([]core.ServicePackError, 0) // This will store any plugin errors received during execution
+
+	for _, cmd := range cmdSet {
+		spErrors, err = Plugin(cmd, spErrors)
+		if err != nil {
+			return
+		}
+	}
+
+	if len(spErrors) > 0 {
+		// Return all service pack errors to main
+		err = &core.ServicePackErrors{
+			SPErrs: spErrors,
+		}
+	}
+	return
+}
+
+// Plugin executes single plugin based on the provided command
+func Plugin(cmd *exec.Cmd, spErrors []core.ServicePackError) ([]core.ServicePackError, error) {
+	// Launch the plugin process
+	client := core.NewClient(cmd)
+	defer client.Kill()
+
+	// Connect via RPC
+	rpcClient, err := client.Client()
+	if err != nil {
+		return spErrors, err
+	}
+
+	// Request the plugin
+	rawSP, err := rpcClient.Dispense(plugin.ServicePackPluginName)
+	if err != nil {
+		return spErrors, err
+	}
+
+	// Execute service pack, expecting a silent response
+	servicePack := rawSP.(plugin.ServicePack)
+	response := servicePack.RunProbes()
+	if response != nil {
+		spErr := core.ServicePackError{
+			ServicePack: cmd.String(), // TODO: retrieve service pack name from interface function
+			Err:         response,
+		}
+		spErrors = append(spErrors, spErr)
+	} else {
+		log.Printf("[INFO] Probes all completed with successful results")
+	}
+	return spErrors, nil
+}


### PR DESCRIPTION
NOTE: 
Any exported functions that are not in `internal/` will need to be maintained.
Previously no functions were publicly exported, so that didn't matter.
This PR adds the following publicly exported functions:
- `run.CLIContext`
- `run.AllPlugins`
- `run.Plugin`
